### PR TITLE
Fix Python Syntax Error: 'lambda' is a builtin

### DIFF
--- a/code/deep/DDC/DDC.py
+++ b/code/deep/DDC/DDC.py
@@ -78,8 +78,8 @@ def train(epoch, model):
         optimizer.zero_grad()
         label_source_pred, loss_mmd = model(data_source, data_target)
         loss_cls = F.nll_loss(F.log_softmax(label_source_pred, dim=1), label_source)
-        lambda = 2 / (1 + math.exp(-10 * (epoch) / epochs)) - 1
-        loss = loss_cls + lambda * loss_mmd
+        lambda_ = 2 / (1 + math.exp(-10 * (epoch) / epochs)) - 1
+        loss = loss_cls + lambda_ * loss_mmd
         loss.backward()
         optimizer.step()
         if i % log_interval == 0:


### PR DESCRIPTION
$ __python -c "lambda = 2"__  # --> SyntaxError

https://docs.python.org/3/reference/expressions.html#lambda