### PR TITLE
modify the bug of mismatch in DaNN.

### DIFF
--- a/code/deep/DaNN/data_loader.py
+++ b/code/deep/DaNN/data_loader.py
@@ -7,7 +7,7 @@ def load_data(root_dir,domain,batch_size):
         transforms.Grayscale(),
         transforms.Resize([28, 28]),
         transforms.ToTensor(),
-        transforms.Normalize(mean=(0,0,0),std=(1,1,1)),
+        transforms.Normalize(mean=(0,),std=(1,)),
     ]
     )
     image_folder = datasets.ImageFolder(
@@ -23,7 +23,7 @@ def load_test(root_dir,domain,batch_size):
         transforms.Grayscale(),
         transforms.Resize([28, 28]),
         transforms.ToTensor(),
-        transforms.Normalize(mean=(0, 0, 0), std=(1, 1, 1)),
+        transforms.Normalize(mean=(0,), std=(1,)),
     ]
     )
     image_folder = datasets.ImageFolder(


### PR DESCRIPTION
Load data with one channel when using Grayscale. Therefore, if continue to use ' transforms.Normalize(mean=(0,0,0),std=(1,1,1)),' in original file, some mistakes will happen.

> RuntimeError: output with shape [1, 28, 28] doesn't match the broadcast shape [3, 28, 28]

This is the only solution because i get back the error message of 'ValueError: Expected input batch_size (192) to match target batch_size (64). '  when i try to comment 'transforms.Grayscale(),' .  
Reason:  code in original main.py file
'''python
        data, target = data.data.view(-1, 28 * 28).to(DEVICE), target.to(DEVICE)
        x_tar, y_target = x_tar.view(-1, 28 * 28).to(DEVICE), y_target.to(DEVICE)
'''