### PR TITLE
Correct typo

### DIFF
--- a/code/DeepDA/DAAN/DAAN.yaml
+++ b/code/DeepDA/DAAN/DAAN.yaml
@@ -14,8 +14,8 @@ lr_gamma: 0.0003
 lr_decay: 0.75
 
 # Training related
-n_iter_per_epoch: 20
-n_epoch: 500
+n_iter_per_epoch: 500
+n_epoch: 20
 
 # Others
 seed: 1


### PR DESCRIPTION
Modification:
From 
```
n_iter_per_epoch: 20
n_epoch: 500
```
To
```
n_iter_per_epoch: 500
n_epoch: 20
```

Because all the other methods have 20 epochs and 500 iterations per epoch