### PR TITLE
Using efficient np.linalg.multi_dot

### DIFF
--- a/code/traditional/CORAL/CORAL.py
+++ b/code/traditional/CORAL/CORAL.py
@@ -26,7 +26,8 @@ class CORAL:
         cov_tar = np.cov(Xt.T) + np.eye(Xt.shape[1])
         A_coral = np.dot(scipy.linalg.fractional_matrix_power(cov_src, -0.5),
                          scipy.linalg.fractional_matrix_power(cov_tar, 0.5))
-        Xs_new = np.real(np.dot(Xs, A_coral))
+        Xs_new = np.real(np.linalg.multi_dot([Xs, scipy.linalg.fractional_matrix_power(cov_src, -0.5),
+                         scipy.linalg.fractional_matrix_power(cov_tar, 0.5))])
         return Xs_new
 
     def fit_predict(self, Xs, Ys, Xt, Yt):

--- a/code/traditional/GFK/GFK.py
+++ b/code/traditional/GFK/GFK.py
@@ -88,8 +88,8 @@ class GFK:
         delta3_2 = np.hstack((np.zeros(shape=(N - dim, dim)), V2))
         delta3 = np.vstack((delta3_1, delta3_2)).T
 
-        delta = np.dot(np.dot(delta1, delta2), delta3)
-        G = np.dot(np.dot(Ps, delta), Ps.T)
+        delta = np.linalg.multi_dot([delta1, delta2, delta3])
+        G = np.linalg.multi_dot([Ps, delta, Ps.T])
         sqG = scipy.real(scipy.linalg.fractional_matrix_power(G, 0.5))
         Xs_new, Xt_new = np.dot(sqG, Xs.T).T, np.dot(sqG, Xt.T).T
         return G, Xs_new, Xt_new

--- a/code/traditional/pyEasyTL/intra_alignment.py
+++ b/code/traditional/pyEasyTL/intra_alignment.py
@@ -58,9 +58,7 @@ def CORAL_map(Xs,Xt):
     cov_tar = np.ma.cov(Dt.T) + np.eye(Dt.shape[1])
     
     Cs = scipy.linalg.sqrtm(np.linalg.inv(np.array(cov_src)))
-    Ct = scipy.linalg.sqrtm(np.array(cov_tar))
-    A_coral = np.dot(Cs, Ct)
-    
-    Xs_new = np.dot(Ds, A_coral)
+    Ct = scipy.linalg.sqrtm(np.array(cov_tar))    
+    Xs_new = np.linalg.multi_dot([Ds, Cs, Ct])
         
     return Xs_new


### PR DESCRIPTION
It is more succinct and effective to refactor code to use `np.linalg.multi_dot` rather than numerous `np.dot` routines. 
What do you think about this change that has practical value?