### PR TITLE
Solve a size mismatch issue in AdaRNN.py

### DIFF
--- a/code/deep/adarnn/base/AdaRNN.py
+++ b/code/deep/adarnn/base/AdaRNN.py
@@ -26,7 +26,7 @@ class AdaRNN(nn.Module):
             rnn = nn.GRU(
                 input_size=in_size,
                 num_layers=1,
-                hidden_size=hidden,
+                hidden_size=len_seq * hidden,
                 batch_first=True,
                 dropout=dropout
             )


### PR DESCRIPTION
`len_seq` changes the input size of gate, which is a linear layer. It should also changes the size of rnn, since the input x will pass rnn first before passing the linear layer