### PR TITLE
fix(sec): upgrade torch to 1.13.1

### DIFF
--- a/code/DeepDA/requirements.txt
+++ b/code/DeepDA/requirements.txt
@@ -1,5 +1,5 @@
 ConfigArgParse==1.4.1
-torch==1.8.1
+torch==1.13.1
 torchvision==0.9.1
 scikit-learn
 matplotlib


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in torch 1.8.1
- [CVE-2022-45907](https://www.oscs1024.com/hd/CVE-2022-45907)


### What did I do？
Upgrade torch from 1.8.1 to 1.13.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS