### PR TITLE
Fix `shuffle` param for `data_loader.py`

### DIFF
--- a/code/DeepDA/data_loader.py
+++ b/code/DeepDA/data_loader.py
@@ -26,9 +26,9 @@ def load_data(data_folder, batch_size, train, num_workers=0, **kwargs):
 
 def get_data_loader(dataset, batch_size, shuffle=True, drop_last=False, num_workers=0, infinite_data_loader=False, **kwargs):
     if not infinite_data_loader:
-        return torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=True, drop_last=drop_last, num_workers=num_workers, **kwargs)
+        return torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last, num_workers=num_workers, **kwargs)
     else:
-        return InfiniteDataLoader(dataset, batch_size=batch_size, shuffle=True, drop_last=drop_last, num_workers=num_workers, **kwargs)
+        return InfiniteDataLoader(dataset, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last, num_workers=num_workers, **kwargs)
 
 class _InfiniteSampler(torch.utils.data.Sampler):
     """Wraps another Sampler to yield an infinite stream."""


### PR DESCRIPTION
`shuffle` parameter is used to check whether the dataset should be shuffled, however the parameter is not passed into the corresponding function.

This PR fix this bug.